### PR TITLE
test: add tests for matching-paths

### DIFF
--- a/packages/matching-paths/test/indext.test.ts
+++ b/packages/matching-paths/test/indext.test.ts
@@ -1,0 +1,116 @@
+import test from "ava";
+import { matchingPaths } from "../src";
+import { createMocks } from "node-mocks-http";
+
+test("matchingPaths - calls callback when path matches", async (t) => {
+  let middlewareCallCount = 0;
+
+  let didMatch = false;
+
+  const wrapped = matchingPaths({ matcher: ["/dashboard/:path*"] }, (next) => {
+    didMatch = true;
+    return next();
+  });
+
+  const httpMock = createMocks({
+    method: "GET",
+    url: new URL("/dashboard", "http://localhost:3000").toString()
+  });
+
+  const middleware = wrapped((req) => {
+    middlewareCallCount += 1;
+    return new Response("OK", { status: 200 });
+  });
+
+  middleware(httpMock.req as any);
+
+  t.is(typeof wrapped, "function");
+  t.is(didMatch, true);
+  t.is(middlewareCallCount, 1);
+});
+
+test("matchingPaths - calls callback path when no matcher provided", async (t) => {
+  let middlewareCallCount = 0;
+
+  let didMatch = false;
+
+  const wrapped = matchingPaths({}, (next) => {
+    didMatch = true;
+    return next();
+  });
+
+  const httpMock = createMocks({
+    method: "GET",
+    url: new URL("/about", "http://localhost:3000").toString()
+  });
+
+  const middleware = wrapped((req) => {
+    middlewareCallCount += 1;
+    return new Response("OK", { status: 200 });
+  });
+
+  middleware(httpMock.req as any);
+
+  t.is(typeof wrapped, "function");
+  t.is(didMatch, true);
+  t.is(middlewareCallCount, 1);
+});
+
+test("matchingPaths - calls callback when empty matcher provided", async (t) => {
+  let middlewareCallCount = 0;
+
+  let didMatch = false;
+
+  const wrapped = matchingPaths(
+    {
+      matcher: []
+    },
+    (next) => {
+      didMatch = true;
+      return next();
+    }
+  );
+
+  const httpMock = createMocks({
+    method: "GET",
+    url: new URL("/about", "http://localhost:3000").toString()
+  });
+
+  const middleware = wrapped((req) => {
+    middlewareCallCount += 1;
+    return new Response("OK", { status: 200 });
+  });
+
+  middleware(httpMock.req as any);
+
+  t.is(typeof wrapped, "function");
+  t.is(didMatch, true);
+  t.is(middlewareCallCount, 1);
+});
+
+test("matchingPaths - does not call callback when path does not match", async (t) => {
+  let middlewareCallCount = 0;
+
+  let didMatch = false;
+
+  const wrapped = matchingPaths({ matcher: ["/dashboard/:path*"] }, (next) => {
+    didMatch = true;
+    return next();
+  });
+
+  const httpMock = createMocks({
+    method: "GET",
+    url: new URL("/about", "http://localhost:3000").toString()
+  });
+
+  const middleware = wrapped((req) => {
+    middlewareCallCount += 1;
+    return new Response("OK", { status: 200 });
+  });
+
+  middleware(httpMock.req as any);
+
+  t.is(typeof wrapped, "function");
+  t.is(didMatch, false);
+  t.is(middlewareCallCount, 1);
+});


### PR DESCRIPTION
This PR adds tests for matching paths. 

It covers the following cases:
* calls middleware callback when there is a match
* calls middleware callback when empty/no matcher is provided in config
* ignores middleware callback when request path does not match matcher